### PR TITLE
Improve word matching with stemming

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ pyinstaller --onefile --name contar_palabras_pdf contar_palabras_pdf.py
 --substrings → cuenta subcadenas (ej. “plan” dentro de “planificación”).
 --keep-accents → no normaliza acentos.
 --recursive → busca PDFs en subcarpetas.
+-- La búsqueda de palabra completa ahora también considera raíces flexionadas
+   (stemming) para encontrar términos relacionados morfológicamente.
 
 
 # EJEMLPLOS USO ESPAÑOL

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 pdfminer.six
 pypdf
 tqdm
+nltk


### PR DESCRIPTION
## Summary
- add stemming-based helpers to extend single-word matches to related roots and keep regex handling for other terms
- wire the new stemming search into the PDF processing flow and document the behavior, updating dependencies as needed

## Testing
- python -m compileall cc_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68dd9adb0130832e86ef62b1895a6f83